### PR TITLE
Add job detail, map markers, chemical calculator

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './app/screens/HomeScreen';
 import MapScreen from './app/screens/MapScreen';
+import JobDetailScreen from './app/screens/JobDetailScreen';
+import ChemicalCalculatorScreen from './app/screens/ChemicalCalculatorScreen';
 import { RootStackParamList } from './app/types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -13,6 +15,8 @@ export default function App() {
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Map" component={MapScreen} />
+        <Stack.Screen name="JobDetail" component={JobDetailScreen} />
+        <Stack.Screen name="ChemCalc" component={ChemicalCalculatorScreen} options={{ title: 'Chemical Calculator' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 This repository contains the **Cabana Man Pool Service** mobile application. The project uses **React Native with Expo** and TypeScript.
 
-The implementation is progressing screen by screen. The first step adds a Home screen with a simple list of today's jobs and a button to view the route map.
+The application provides a home screen listing today's jobs with options to view each job, see a route map with stops, and run a basic chemical calculator.
 
 ## Folder Structure
 
 - `App.tsx` - Application entry point with React Navigation.
 - `app/`
-  - `components/` - Reusable UI components (to be implemented).
+  - `components/` - Reusable UI components.
+    - `JobItem.tsx` - List item for a job.
   - `screens/` - App screens.
     - `HomeScreen.tsx` - Shows today's jobs and total stops.
-    - `MapScreen.tsx` - Placeholder for route map.
-  - `database/` - Local storage helpers (to be implemented).
+    - `MapScreen.tsx` - Displays the route map for today's jobs.
+    - `JobDetailScreen.tsx` - Displays details about a job.
+    - `ChemicalCalculatorScreen.tsx` - Simple pool chemical calculator.
+  - `database/` - Local storage helpers.
   - `types/` - Shared TypeScript types.
 
 ## Getting Started
@@ -27,4 +30,4 @@ The implementation is progressing screen by screen. The first step adds a Home s
    ```
 3. Use the Expo Go app or an emulator to run the project.
 
-Next steps will add the Job List, Job Detail, Route Map functionality, chemical calculator, and local storage.
+This example includes a simple job list with detail screens, a route map and chemical calculator. Job data is stored locally using AsyncStorage.

--- a/app/components/JobItem.tsx
+++ b/app/components/JobItem.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Job } from '../types';
+
+interface Props {
+  job: Job;
+  onPress?: () => void;
+}
+
+export default function JobItem({ job, onPress }: Props) {
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.container}>
+      <Text style={styles.customer}>{job.customer}</Text>
+      {job.address ? <Text style={styles.address}>{job.address}</Text> : null}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
+  },
+  customer: {
+    fontSize: 16,
+  },
+  address: {
+    fontSize: 14,
+    color: '#555',
+  },
+});

--- a/app/database/jobs.ts
+++ b/app/database/jobs.ts
@@ -1,0 +1,20 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Job } from '../types';
+
+const JOBS_KEY = 'jobs';
+
+export async function loadJobs(): Promise<Job[]> {
+  const json = await AsyncStorage.getItem(JOBS_KEY);
+  if (json) {
+    try {
+      return JSON.parse(json) as Job[];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export async function saveJobs(jobs: Job[]): Promise<void> {
+  await AsyncStorage.setItem(JOBS_KEY, JSON.stringify(jobs));
+}

--- a/app/screens/ChemicalCalculatorScreen.tsx
+++ b/app/screens/ChemicalCalculatorScreen.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+export default function ChemicalCalculatorScreen() {
+  const [volume, setVolume] = useState('');
+  const [result, setResult] = useState<number | null>(null);
+
+  const calculate = () => {
+    const v = parseFloat(volume);
+    if (!isNaN(v)) {
+      // Extremely simplified: chlorine ounces = volume * 0.00013
+      setResult(v * 0.00013);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Chemical Calculator</Text>
+      <TextInput
+        placeholder="Pool volume (gallons)"
+        keyboardType="numeric"
+        value={volume}
+        onChangeText={setVolume}
+        style={styles.input}
+      />
+      <Button title="Calculate" onPress={calculate} />
+      {result !== null && (
+        <Text style={styles.result}>Ounces of chlorine: {result.toFixed(2)}</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  header: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  result: {
+    marginTop: 12,
+    fontSize: 16,
+  },
+});

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList, Job } from '../types';
+import JobItem from '../components/JobItem';
+import { loadJobs } from '../database/jobs';
 
-const jobs: Job[] = [
+const defaultJobs: Job[] = [
   { id: '1', customer: 'Smith Family', address: '123 Palm Rd' },
   { id: '2', customer: 'Jones Estate', address: '456 Ocean Ave' },
   { id: '3', customer: 'Liu Residence', address: '789 Sunset Blvd' },
@@ -12,6 +14,17 @@ const jobs: Job[] = [
 
 export default function HomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const [jobs, setJobs] = useState<Job[]>([]);
+
+  useEffect(() => {
+    loadJobs().then((stored) => {
+      if (stored.length === 0) {
+        setJobs(defaultJobs);
+      } else {
+        setJobs(stored);
+      }
+    });
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -20,13 +33,17 @@ export default function HomeScreen() {
         data={jobs}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <View style={styles.jobItem}>
-            <Text style={styles.jobText}>{item.customer}</Text>
-            <Text style={styles.jobAddress}>{item.address}</Text>
-          </View>
+          <JobItem
+            job={item}
+            onPress={() => navigation.navigate('JobDetail', { job: item })}
+          />
         )}
       />
-      <Button title="View Route Map" onPress={() => navigation.navigate('Map')} />
+      <Button title="View Route Map" onPress={() => navigation.navigate('Map', { jobs })} />
+      <Button
+        title="Chemical Calculator"
+        onPress={() => navigation.navigate('ChemCalc')}
+      />
     </View>
   );
 }
@@ -41,17 +58,5 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     marginBottom: 12,
-  },
-  jobItem: {
-    paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#ccc',
-  },
-  jobText: {
-    fontSize: 16,
-  },
-  jobAddress: {
-    fontSize: 14,
-    color: '#555',
   },
 });

--- a/app/screens/JobDetailScreen.tsx
+++ b/app/screens/JobDetailScreen.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { RootStackParamList } from '../types';
+
+export default function JobDetailScreen() {
+  const route = useRoute<RouteProp<RootStackParamList, 'JobDetail'>>();
+  const { job } = route.params;
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>{job.customer}</Text>
+      <Text style={styles.address}>{job.address}</Text>
+      {job.notes ? <Text style={styles.notes}>{job.notes}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  header: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  address: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  notes: {
+    fontSize: 14,
+  },
+});

--- a/app/screens/MapScreen.tsx
+++ b/app/screens/MapScreen.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { RootStackParamList, Job } from '../types';
 
 export default function MapScreen() {
+  const route = useRoute<RouteProp<RootStackParamList, 'Map'>>();
+  const jobs: Job[] = route.params?.jobs || [];
   return (
     <View style={styles.container}>
-      <Text>Route Map will be implemented later.</Text>
+      <MapView style={StyleSheet.absoluteFillObject}>
+        {jobs.map((job) =>
+          job.location ? (
+            <Marker
+              key={job.id}
+              coordinate={job.location}
+              title={job.customer}
+              description={job.address}
+            />
+          ) : null
+        )}
+      </MapView>
     </View>
   );
 }
@@ -12,7 +28,5 @@ export default function MapScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -2,9 +2,16 @@ export interface Job {
   id: string;
   customer: string;
   address: string;
+  notes?: string;
+  location?: {
+    latitude: number;
+    longitude: number;
+  };
 }
 
 export type RootStackParamList = {
   Home: undefined;
-  Map: undefined;
+  Map: { jobs: Job[] } | undefined;
+  JobDetail: { job: Job };
+  ChemCalc: undefined;
 };


### PR DESCRIPTION
## Summary
- add local storage helpers
- add reusable JobItem component
- show stored jobs on Home screen and link to detail, map and calculator
- add job detail and chemical calculator screens
- display markers for job locations on the map
- update navigation
- expand README documentation

## Testing
- `npm install --legacy-peer-deps`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68899eff64e083318e88577843eacd20